### PR TITLE
Added to_a to releases on #last_release_with_slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.2
+
+- Fixed reverse call on enumerator on `Paratrooper::HerokuWrapper#last_release_with_slug`
+
 ## 3.0.1
 
 - Migrated to platform-api gem from heroku

--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -55,7 +55,8 @@ module Paratrooper
     end
 
     def last_release_with_slug
-      releases.reverse.detect { |release| not release['slug'].nil? }
+      # releases is an enumerator
+      releases.to_a.reverse.detect { |release| not release['slug'].nil? }
     end
 
     private

--- a/lib/paratrooper/version.rb
+++ b/lib/paratrooper/version.rb
@@ -1,3 +1,3 @@
 module Paratrooper
-  VERSION = "3.0.1".freeze
+  VERSION = "3.0.2".freeze
 end


### PR DESCRIPTION
* Apparently the new heroku client treats the release list lazy
  so it wont produce any results until it's commanded so it only returns
  an enumerator, adding the to_a to the releases call on the heroku_wrapper
  #last_release_with_slug will do this for us